### PR TITLE
Seth no longer responds with confirmation when mistyping a target

### DIFF
--- a/commands/dosh.js
+++ b/commands/dosh.js
@@ -70,7 +70,11 @@ exports.run = function(msg, currentDosh) {
 
   //check to see if the user has tried to vote for the same target within 30 minutes
   //false means that they have, true means that they have not voted.
-  var isValid = checkHistory(msg, targets);
+  if(targets != false) {
+    var isValid = checkHistory(msg, targets);
+  } else {
+    return false;
+  }
 
   if(isValid != false) {
 


### PR DESCRIPTION
Noticed an issue where if you mistype a target (example !dosh trump --) it would give the appropriate rejection message but then also reply with a confirmation response as well.  This change has fixed it so it'll only respond with one and with the correct one.