### PR TITLE
Karma map is ingested on start up

### DIFF
--- a/commands/dosh.js
+++ b/commands/dosh.js
@@ -30,6 +30,10 @@ function updateKarmaMap(){
   }
 }
 
+exports.init = function(bot, config) {
+  updateKarmaMap();
+}
+
 
 //Key: messageid ::: Value: collection<integer> (Discord UserIDs of members who reacted to a message )
 const usersWhoReacted = new Map();


### PR DESCRIPTION
I just used the current branch I was on.  Either way I created an init function to insure that the karma gets ingested before any action is registered.